### PR TITLE
Bugfix keyActive() vs keyPressed()

### DIFF
--- a/BBQ10/BBQ10.ino
+++ b/BBQ10/BBQ10.ino
@@ -483,7 +483,7 @@ void printMatrix() {
           toPrint = keyboard_cursor[colIndex][rowIndex];
           other1  = keyboard[colIndex][rowIndex];
           other2  = keyboard_symbol[colIndex][rowIndex];
-        } else if (stickySym != STICKY_STATUS_OPEN || keyPressed(K_SYM)) {
+        } else if (stickySym != STICKY_STATUS_OPEN || keyActive(K_SYM)) {
           toPrint = keyboard_symbol[colIndex][rowIndex];
           other1  = keyboard[colIndex][rowIndex];
           other2  = keyboard_cursor[colIndex][rowIndex];
@@ -494,14 +494,14 @@ void printMatrix() {
         }
   
         // Workaround for left shift key dropping while being pressed
-        if (keyPressed(K_LSH) && rowIndex!=1 && colIndex!=6) {
+        if (keyActive(K_LSH) && rowIndex!=1 && colIndex!=6) {
           KEYBOARD_RELEASE(KEY_LEFT_SHIFT);
           KEYBOARD_PRESS(KEY_LEFT_SHIFT);
         }
         if (keyPressed(colIndex, rowIndex)) {
           if (toPrint!=NULL) {
-            if (stickyLsh != STICKY_STATUS_OPEN && !keyPressed(K_LSH)) { KEYBOARD_PRESS(KEY_LEFT_SHIFT); }
-            if (stickyRsh != STICKY_STATUS_OPEN && !keyPressed(K_RSH)) { KEYBOARD_PRESS(KEY_RIGHT_SHIFT); }
+            if (stickyLsh != STICKY_STATUS_OPEN && !keyActive(K_LSH)) { KEYBOARD_PRESS(KEY_LEFT_SHIFT); }
+            if (stickyRsh != STICKY_STATUS_OPEN && !keyActive(K_RSH)) { KEYBOARD_PRESS(KEY_RIGHT_SHIFT); }
             if (stickyCtrl!= STICKY_STATUS_OPEN && !keyActive(K_MIC)) { KEYBOARD_PRESS(KEY_LEFT_CTRL); }
             if (stickyAlt != STICKY_STATUS_OPEN && !keyActive(K_ALT)) { KEYBOARD_PRESS(KEY_LEFT_ALT); }
             KEYBOARD_PRESS(toPrint);
@@ -516,8 +516,8 @@ void printMatrix() {
           if (other2!=NULL) {
             KEYBOARD_RELEASE(other2);
           }
-          if (!keyPressed(K_LSH)) { KEYBOARD_RELEASE(KEY_LEFT_SHIFT); }
-          if (!keyPressed(K_RSH)) { KEYBOARD_RELEASE(KEY_RIGHT_SHIFT); }
+          if (!keyActive(K_LSH)) { KEYBOARD_RELEASE(KEY_LEFT_SHIFT); }
+          if (!keyActive(K_RSH)) { KEYBOARD_RELEASE(KEY_RIGHT_SHIFT); }
           if (!keyActive(K_MIC)) { KEYBOARD_RELEASE(KEY_LEFT_CTRL); }
           if (!keyActive(K_ALT)) { KEYBOARD_RELEASE(KEY_LEFT_ALT); }
         }

--- a/Case/Generator/Fairberry.scad
+++ b/Case/Generator/Fairberry.scad
@@ -3,7 +3,7 @@
 // Version 2
 
 SCREEN_PROTECTOR_HEIGHT=0.6; // Thickness of the screen protector
-EXTRUSION_WIDTH=0.4; // Extrusion width of your 3D printer
+EXTRUSION_WIDTH=0.48; // Extrusion width of your 3D printer
 
 // Uncomment the type of phone you use. If your phone doesn't appear in this list, leave "include <presets/Custom.scad>" and edit the file at presets/Custom.scad to fit your phone.
 include <presets/Custom.scad>

--- a/Case/Generator/presets/Custom.scad
+++ b/Case/Generator/presets/Custom.scad
@@ -29,4 +29,4 @@ CASE_TOP_ROUNDING_OFFSET=1; // Increasing this number makes the top less rounded
 
 KEYBOARD_PHONE_GAP_PERIMETERS=2; // Thickness of the separator between keyboard and phone screen
 
-FORCE_HOLE_CUTAWAYS=true;
+FORCE_HOLE_CUTAWAYS=true; // Will cut holes for USB and speakers even if a dummy file is selected. Use this if the holes aren't included in the dummy file.


### PR DESCRIPTION
Some checks that should be based on keyActive() where instead based on keyPressed() which leads to accidentally dropped sticky conditions.